### PR TITLE
Improved TimeComplexity  for worst cases of Bubble and Quick Sort

### DIFF
--- a/C++/Sorting/BubbleSortModified.cpp
+++ b/C++/Sorting/BubbleSortModified.cpp
@@ -1,0 +1,37 @@
+#include<iostream>
+#include<vector>
+using namespace std;
+int main()
+{
+    int n;
+    cout<<"Enter the number of elements:"<<endl;
+    cin>>n;
+    vector<int>arr(n);
+    cout<<"Enter the elements:"<<endl;
+    for(int i=0;i<n;i++){
+        cin>>arr[i];
+    }
+    int i, j;
+    bool swapped;
+    for (i = 0; i < n - 1; i++)
+    {
+        swapped = false;
+        for (j = 0; j < n - i - 1; j++)
+        {
+        
+            if (arr[j] > arr[j + 1]){
+                swap(arr[j], arr[j + 1]);
+                swapped=true;
+            }
+        }
+        if(swapped==false){
+            break;
+        }
+
+    }
+    cout<<"Sorted Array using Bubble Sort"<<endl;
+    for(int i=0;i<n;i++){
+        cout<<arr[i]<<" ";
+    }
+    return 0;
+}

--- a/C++/Sorting/Randomized_QuickSort.cpp
+++ b/C++/Sorting/Randomized_QuickSort.cpp
@@ -1,0 +1,56 @@
+#include<iostream>
+using namespace std;
+
+void quickSort(int arr[],int lb,int ub)
+{
+    if(lb>=ub)
+    {
+        return ;
+    }
+    
+    int i=lb,j=ub;
+    int x=rand()%(ub-lb+1)+lb;
+    swap(arr[x],arr[lb]);
+    
+    int pivot=arr[lb];
+    
+    while(i<j)
+    {
+        while( i<j && arr[i]<=pivot)
+        i++;
+        
+        while(arr[j]>pivot)
+        j--;
+        
+        if(i<j)
+        {
+            swap(arr[i],arr[j]);
+        }
+    }
+    arr[lb]=arr[j];
+    arr[j]=pivot;
+    
+    quickSort(arr,lb,j-1);
+    quickSort(arr,j+1,ub);
+}
+int main()
+{
+    int n;
+    cout<<"enter the size of array \n";
+    cin>>n;
+    
+    int arr[n];
+    cout<<"Enter "<<n<<" elements \n";
+    for(int i=0;i<n;i++)
+    {
+        cin>>arr[i];
+    }
+    
+    cout<<"Sorted Array is as follows \n";
+    quickSort(arr,0,n-1);
+    for(int i=0;i<n;i++)
+    {
+        cout<<arr[i]<<" ";
+    }
+    return 0;
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Issue (Number)

Issue no #325

## 👨‍💻 Changes proposed

In Bubble Sort the worst case time complexity is O(n^2) it can be reduced to O(n) by using a flag which will identify if the array is already sorted and hence will reduce the time complexity.
In Quick Sort worst case time complexity is O(n^2) it can be improved by using a random pivot generator which will improve the locality of reference and will improve the time complexity to O(nlogn).

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [✅ ] My code follows the code style of this project.
- [ ✅] This PR does not contain plagiarized content.
- [✅ ] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
![image](https://user-images.githubusercontent.com/99111449/212235444-92a882ec-adb6-4244-b5b1-c85f8a3a416f.png)
